### PR TITLE
Add kafka-lag-exporter to index.yaml so that it can be installed by Helm

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+entries:
+  kafka-lag-exporter:
+    - created: 2020-10-14T15:55:00.000000000+01:00 
+      description: Lightbend Kafka Lag Exporter
+      digest: sha256:383797f7cc37daf9b63e8eb8e7b6bb3d948c07ff86a82474c0792e2160ee56ac
+      home: https://github.com/lightbend/kafka-lag-exporter
+      name: kafka-lag-exporter
+      sources:
+      - https://github.com/lightbend/kafka-lag-exporter
+      urls:
+      - https://github.com/lightbend/kafka-lag-exporter/releases/download/v0.6.5/kafka-lag-exporter-0.6.5.tgz
+      version: 0.6.5
+


### PR DESCRIPTION
We want to be able to install kafka-lag-exporter using the depencendy in the Chart.yaml file, so that we have to serve it via Helm repo.